### PR TITLE
Prepend `Bot ` before the token for authorization

### DIFF
--- a/examples/pingpong/README.md
+++ b/examples/pingpong/README.md
@@ -1,0 +1,12 @@
+# pingpong
+Simple ping bot, to get up to speed quickly with dgrouter
+## How to use
+```
+./pingpong -t <BOT_TOKEN> -p !
+```
+## Flags
+
+| Flag | description |
+|------|-------------|
+| t    | bot token   |
+| p    | bot prefix  |

--- a/examples/pingpong/pingpong.go
+++ b/examples/pingpong/pingpong.go
@@ -19,7 +19,7 @@ var (
 func main() {
 	flag.Parse()
 
-	s, err := discordgo.New(*fToken)
+	s, err := discordgo.New("Bot " + *fToken)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
I was debugging until late for this, maybe it was just my fault for not prepending the `Bot ` word.